### PR TITLE
Add CF CLI output to VSTS variable so it can be used in the pipeline

### DIFF
--- a/Extension/CloudFoundryCLI/cloudfoundrycli.ts
+++ b/Extension/CloudFoundryCLI/cloudfoundrycli.ts
@@ -65,10 +65,16 @@ if (!cfPath) {
             if (args) {
                 cfCmd.line(args);
             }
-            cfCmd.exec()
-                .fail(function (err) {
-                    tl.setResult(tl.TaskResult.Failed, '' + err);
-                });
+            
+            var cfResult = cfCmd.execSync();
+            
+            if(cfResult.error != null){
+                tl.setResult(tl.TaskResult.Failed, '' + cfResult.error);
+            }
+            else{
+                tl.setVariable("CfCliOutput", cfResult.stdout, false);
+                tl.setResult(tl.TaskResult.Succeeded, "")
+            }
         })
         .fail(function (err) {
             tl.error(err);

--- a/Extension/CloudFoundryCLI/task.json
+++ b/Extension/CloudFoundryCLI/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": 0,
-        "Minor": 136,
+        "Minor": 137,
         "Patch": 0
     },
     "groups": [
@@ -117,6 +117,12 @@
         "required": false,
         "helpMarkDown": "Optionally specify the location to the cf CLI. If location is not specified, cf CLI needs to be in the PATH.",
         "groupName": "advanced"
+      }
+    ],
+    "OutputVariables":[
+      {
+        "name": "CfCliOutput",
+        "description": "Output of Cloud Foundry CLI Command"
       }
     ],
     "execution": {

--- a/Extension/CloudFoundryCLI/task.loc.json
+++ b/Extension/CloudFoundryCLI/task.loc.json
@@ -13,7 +13,7 @@
   "demands": [],
   "version": {
     "Major": 0,
-    "Minor": 136,
+    "Minor": 137,
     "Patch": 0
   },
   "groups": [
@@ -117,6 +117,12 @@
       "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.cfToolLocation",
       "groupName": "advanced"
+    }
+  ],
+  "OutputVariables": [
+    {
+      "name": "CfCliOutput",
+      "description": "Output of Cloud Foundry CLI Command"
     }
   ],
   "execution": {

--- a/Extension/extension-manifest.json
+++ b/Extension/extension-manifest.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "cloud-foundry-build-extension",
     "name": "Cloud Foundry",
-    "version": "1.136.0",
+    "version": "1.137.0",
     "publisher": "ms-vsts",
     "description": "Cloud Foundry build extension to push applications to a Cloud Foundry instance.",
     "public": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2776,8 +2776,7 @@
     "mockery": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
-      "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8=",
-      "dev": true
+      "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
     },
     "ms": {
       "version": "2.0.0",
@@ -3450,8 +3449,7 @@
     "shelljs": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
-      "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
-      "dev": true
+      "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E="
     },
     "sigmund": {
       "version": "1.0.1",
@@ -4306,7 +4304,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.4.0.tgz",
       "integrity": "sha512-AqKNrYw6ebzlaV6o09TTWE9LxcywQPanPeocss8BUJXJFEMLRYr3ZyzzjM+lvvsgcYth74VXoHtkBonBpx//Tg==",
-      "dev": true,
       "requires": {
         "minimatch": "3.0.4",
         "mockery": "1.7.0",
@@ -4320,7 +4317,6 @@
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true,
           "requires": {
             "brace-expansion": "1.1.11"
           }
@@ -4328,8 +4324,7 @@
         "semver": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-          "dev": true
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -35,15 +35,14 @@
     "mocha": "^2.3.3",
     "semver": "^4.3.3",
     "shelljs": "^0.3.0",
-    "tfx-cli": "^0.3.0",
     "through2": "^0.6.3",
     "typescript": "^2.4.1",
-    "validator": "^3.33.0",
-    "vsts-task-lib": "^2.0.5"
+    "validator": "^3.33.0"
   },
   "dependencies": {
     "process": "^0.10.1",
     "q": "^1.2.0",
-    "tfx-cli": "^0.3.12"
+    "tfx-cli": "^0.3.12",
+    "vsts-task-lib": "^2.0.5"
   }
 }


### PR DESCRIPTION
When you run a CLI command it can be often useful to get it's output back to a variable so you can use it later in your pipeline. I've added this by adding a output variable in the VSTS task.json and updated the typescript code to write back the CLI output back to this output variable.

I've tested it by creating my own task based on this one in my own pipeline.